### PR TITLE
condense funct_name rule in parser

### DIFF
--- a/lib/svelYacc.py
+++ b/lib/svelYacc.py
@@ -165,8 +165,7 @@ def p_assignment_expr(p):
 def p_funct_name(p):
     '''
     funct_name : __MAIN__
-                | ID
-                | STRINGLITERAL
+                | primary_expr
     '''
     p[0] = Node('funct_name', [], p[1])
 


### PR DESCRIPTION
Condensed because funct_name is some sort of string literal -- it can be a direct STRINGLITERAL, an ID, a result of an array access (names[0]), or a function call that returns a string. The tree walker must type check this
