### PR TITLE
fixed issue with 'identifier list' being appended to list conversions

### DIFF
--- a/lib/svelTraverse.py
+++ b/lib/svelTraverse.py
@@ -688,7 +688,8 @@ class SvelTraverse(object):
 
 		# -> LBRACE identifier_list RBRACE
 		elif tree.leaf == '{':
-			line += '[' + str(self.walk(tree.children[0], verbose=verbose)) + ']'
+			code, _type = self.walk(tree.children[0], verbose=verbose)
+			line += '[' + str(code) + ']'
 			return line, "array" # TODO (emily) type of array
 
 		print "WARNING Unreachable code : _secondary_expr"


### PR DESCRIPTION
**Issue:**

```
$ python testParser.py 7

.
.
.
def arrays(x, y, z):
    a = [('x, y, z', 'identifier_list')]  <---- this line!
    b = a[1]

if __name__ == '__main__':
    main()
```

**Fix:** I think the issue was that _identifier_list was returning a tuple (code, type) and secondary expression was appending a string representation of this tuple instead of only appending the code part. Now:

```
$ python testParser.py 7

.
.
.
def arrays(x, y, z):
    a = [x, y, z]
    b = a[1]

if __name__ == '__main__':
    main()
```

I'm not sure if this creates more issues with the type/scope checking that Emily implemented.
